### PR TITLE
update oshi 5.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <dependency>
       <groupId>com.github.oshi</groupId>
       <artifactId>oshi-core</artifactId>
-      <version>4.4.2</version>
+      <version>5.6.1</version>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>


### PR DESCRIPTION
Our setup currently includes [kamon](https://github.com/kamon-io/Kamon) and lightstep metrics library. Due to major version mismatch, API's are incompatible which prevents usage of updated lightstep reporter in our setup.
Kamon depends on oshi v5+, and hence this is a proposal to upgrade oshi to make them compatible.

@malafeev could you please review this and provide some feedback on this? Could you also provide some ideas as to next steps etc.